### PR TITLE
[#11] Fixed typos and examples indentation

### DIFF
--- a/lib/noether.ex
+++ b/lib/noether.ex
@@ -3,9 +3,9 @@ defmodule Noether do
   Noether aims to ease common data manipulation tasks by introducing simple algebraic functions and other utilities.
   Functions and names are inspired (sometimes taken as-is) from Haskell.
 
-  The `Maybe` module introduces operations on nullable values.
-  The `Either` module introduces operations on `{:ok, _} | {:error, _}` values.
-  The `List` module introduces operations on lists.
+  The `Noether.Maybe` module introduces operations on nullable values.    
+  The `Noether.Either` module introduces operations on `{:ok, _} | {:error, _}` values.    
+  The `Noether.List` module introduces operations on lists.
 
   The root module has a few simple functions one might find of use.
   """
@@ -13,9 +13,10 @@ defmodule Noether do
   @doc """
   Takes a tuple and a function of arity 2. It applies the two values in the tuple to the function.
 
-  ## Example
-    iex> curry({1, 2}, &Kernel.+/2)
-    3
+  ## Examples
+
+      iex> curry({1, 2}, &Kernel.+/2)
+      3
   """
   @spec curry(tuple(), fun()) :: any()
   def curry({a, b}, f), do: f.(a, b)
@@ -23,9 +24,10 @@ defmodule Noether do
   @doc """
   Takes two values and applies them to a function or arity 1 in form of a tuple.
 
-  ## Example
-    iex> uncurry(1, 2, &(&1))
-    {1, 2}
+  ## Examples
+
+      iex> uncurry(1, 2, &(&1))
+      {1, 2}
   """
   @spec uncurry(any(), any(), fun()) :: any()
   def uncurry(a, b, f), do: f.({a, b})
@@ -34,9 +36,10 @@ defmodule Noether do
   Takes a function of arity 2 and returns the same function with its arguments in reverse order, i.e., "flipped".
   Please note that if a function of different arity is given, a function of arity 2 is returned where the two arguments will be applied to the given function.
 
-  ## Example
-    iex> flip(&Kernel.-/2).(3, 4)
-    1
+  ## Examples
+
+      iex> flip(&Kernel.-/2).(3, 4)
+      1
   """
   @spec flip(fun()) :: fun()
   def flip(f), do: fn a, b -> f.(b, a) end

--- a/lib/noether.ex
+++ b/lib/noether.ex
@@ -10,6 +10,9 @@ defmodule Noether do
   The root module has a few simple functions one might find of use.
   """
 
+  @type fun1 :: (any() -> any())
+  @type fun2 :: (any(), any() -> any())
+
   @doc """
   Takes a tuple and a function of arity 2. It applies the two values in the tuple to the function.
 
@@ -18,8 +21,8 @@ defmodule Noether do
       iex> curry({1, 2}, &Kernel.+/2)
       3
   """
-  @spec curry(tuple(), fun()) :: any()
-  def curry({a, b}, f), do: f.(a, b)
+  @spec curry(tuple(), fun2()) :: any()
+  def curry({a, b}, f) when is_function(f, 2), do: f.(a, b)
 
   @doc """
   Takes two values and applies them to a function or arity 1 in form of a tuple.
@@ -29,8 +32,8 @@ defmodule Noether do
       iex> uncurry(1, 2, &(&1))
       {1, 2}
   """
-  @spec uncurry(any(), any(), fun()) :: any()
-  def uncurry(a, b, f), do: f.({a, b})
+  @spec uncurry(any(), any(), fun1()) :: any()
+  def uncurry(a, b, f) when is_function(f, 1), do: f.({a, b})
 
   @doc """
   Takes a function of arity 2 and returns the same function with its arguments in reverse order, i.e., "flipped".
@@ -41,6 +44,6 @@ defmodule Noether do
       iex> flip(&Kernel.-/2).(3, 4)
       1
   """
-  @spec flip(fun()) :: fun()
-  def flip(f), do: fn a, b -> f.(b, a) end
+  @spec flip(fun2()) :: fun2()
+  def flip(f) when is_function(f, 2), do: fn a, b -> f.(b, a) end
 end

--- a/lib/noether/either.ex
+++ b/lib/noether/either.ex
@@ -10,12 +10,13 @@ defmodule Noether.Either do
   Given an `{:ok, value}` and a function, it applies the function on the `value` returning `{:ok, f.(value)}`.
   If an `{:error, _}` is given, it is returned as-is.
 
-  ## EXAMPLES
-    iex> map({:ok, -1}, &Kernel.abs/1)
-    {:ok, 1}
+  ## Examples
 
-    iex> map({:error, "Value not found"}, &Kernel.abs/1)
-    {:error, "Value not found"}
+      iex> map({:ok, -1}, &Kernel.abs/1)
+      {:ok, 1}
+
+      iex> map({:error, "Value not found"}, &Kernel.abs/1)
+      {:error, "Value not found"}
   """
   @spec map(either(), fun1()) :: either()
   def map({:ok, a}, f) when is_function(f, 1), do: {:ok, f.(a)}
@@ -25,18 +26,19 @@ defmodule Noether.Either do
   Given an `{:ok, {:ok, value}}` it flattens the ok unwrapping the `value` and returning `{:ok, value}`.
   If an `{:error, _}` is given, it is returned as-is.
 
-  ## EXAMPLES
-    iex> flat_map({:ok, {:ok, 1}}, &(&1 + 1))
-    {:ok, 2}
+  ## Examples
 
-    iex> flat_map({:ok, {:error, "Value not found"}}, &(&1 + 1))
-    {:error, "Value not found"}
+      iex> flat_map({:ok, {:ok, 1}}, &(&1 + 1))
+      {:ok, 2}
 
-    iex> flat_map({:ok, 1}, &(&1 + 1))
-    ** (FunctionClauseError) no function clause matching in Noether.Either.flat_map/2
+      iex> flat_map({:ok, {:error, "Value not found"}}, &(&1 + 1))
+      {:error, "Value not found"}
 
-    iex> flat_map({:error, "Value not found"}, &(&1 + 1))
-    {:error, "Value not found"}
+      iex> flat_map({:ok, 1}, &(&1 + 1))
+      ** (FunctionClauseError) no function clause matching in Noether.Either.flat_map/2
+
+      iex> flat_map({:error, "Value not found"}, &(&1 + 1))
+      {:error, "Value not found"}
   """
   @spec flat_map(either(), fun1()) :: either()
   def flat_map({:ok, {:ok, a}}, f) when is_function(f, 1), do: {:ok, f.(a)}
@@ -47,15 +49,16 @@ defmodule Noether.Either do
   Given an `{:ok, {:ok, value}}` it flattens the ok unwrapping the `value` and returning `{:ok, value}`.
   If an `{:error, _}` is given, it is returned as-is.
 
-  ## EXAMPLES
-    iex> join({:ok, {:ok, 1}})
-    {:ok, 1}
+  ## Examples
 
-    iex> join({:ok, 1})
-    ** (FunctionClauseError) no function clause matching in Noether.Either.join/1
+      iex> join({:ok, {:ok, 1}})
+      {:ok, 1}
 
-    iex> join({:error, "Value not found"})
-    {:error, "Value not found"}
+      iex> join({:ok, 1})
+      ** (FunctionClauseError) no function clause matching in Noether.Either.join/1
+
+      iex> join({:error, "Value not found"})
+      {:error, "Value not found"}
   """
   @spec join(either()) :: either()
   def join({:ok, {:ok, a}}), do: {:ok, a}
@@ -66,15 +69,16 @@ defmodule Noether.Either do
   Given an `{:ok, value}` and a function that returns an Either value, it applies the function on the `value`. It effectively "squashes" an `{:ok, {:ok, v}}` or `{:ok, {:error, _}}` to its most appropriate representation.
   If an `{:error, _}` is given, it is returned as-is.
 
-  ## EXAMPLES
-    iex> bind({:ok, 1}, fn a -> {:ok, a + 1} end)
-    {:ok, 2}
+  ## Examples
 
-    iex> bind({:ok, 1}, fn _ -> {:error, 5} end)
-    {:error, 5}
+      iex> bind({:ok, 1}, fn a -> {:ok, a + 1} end)
+      {:ok, 2}
 
-    iex> bind({:error, 1}, fn _ -> {:ok, 45} end)
-    {:error, 1}
+      iex> bind({:ok, 1}, fn _ -> {:error, 5} end)
+      {:error, 5}
+
+      iex> bind({:error, 1}, fn _ -> {:ok, 45} end)
+      {:error, 1}
   """
   @spec bind(either(), fun1()) :: either()
   def bind({:ok, a}, f) when is_function(f, 1), do: f.(a)
@@ -83,15 +87,16 @@ defmodule Noether.Either do
   @doc """
   Given any value, it makes sure the result is an Either type.
 
-  ## EXAMPLES
-    iex> wrap({:ok, 1})
-    {:ok, 1}
+  ## Examples
 
-    iex> wrap({:error, 2})
-    {:error, 2}
+      iex> wrap({:ok, 1})
+      {:ok, 1}
 
-    iex> wrap(3)
-    {:ok, 3}
+      iex> wrap({:error, 2})
+      {:error, 2}
+
+      iex> wrap(3)
+      {:ok, 3}
   """
   @spec wrap(any()) :: either()
   def wrap(k = {:ok, _}), do: k
@@ -101,12 +106,13 @@ defmodule Noether.Either do
   @doc """
   It returns the value of an `{:ok, value}` only if such a tuple is given. If not, `nil` is returned.
 
-  ## EXAMPLES
-    iex> unwrap({:ok, 1})
-    1
+  ## Examples
 
-    iex> unwrap(2)
-    nil
+      iex> unwrap({:ok, 1})
+      1
+
+      iex> unwrap(2)
+      nil
   """
   @spec unwrap({:ok, any()}) :: any()
   def unwrap({:ok, v}), do: v
@@ -115,15 +121,16 @@ defmodule Noether.Either do
   @doc """
   It returns `true` only if the value given matches a `{:ok, value}` type.
 
-  ## EXAMPLES
-    iex> ok?({:ok, 1})
-    true
+  ## Examples
 
-    iex> ok?({:error, 2})
-    false
+      iex> ok?({:ok, 1})
+      true
 
-    iex> ok?(3)
-    false
+      iex> ok?({:error, 2})
+      false
+
+      iex> ok?(3)
+      false
   """
   @spec ok?(any()) :: boolean()
   def ok?(any), do: match?({:ok, _}, any)
@@ -131,15 +138,16 @@ defmodule Noether.Either do
   @doc """
   It returns `true` only if the value given matches a `{:error, value}` type.
 
-  ## EXAMPLES
-    iex> error?({:ok, 1})
-    false
+  ## Examples
 
-    iex> error?({:error, 2})
-    true
+      iex> error?({:ok, 1})
+      false
 
-    iex> error?(3)
-    false
+      iex> error?({:error, 2})
+      true
+
+      iex> error?(3)
+      false
   """
   @spec error?(any()) :: boolean()
   def error?(any), do: match?({:error, _}, any)
@@ -147,15 +155,16 @@ defmodule Noether.Either do
   @doc """
   Given a list of Either, it returns `{:ok, list}` if every element of the list is of type `{:ok, _}`. Otherwise the first `{:error, _}` is returned.
 
-  ## EXAMPLES
-    iex> sequence([{:ok, 1}, {:ok, 2}])
-    {:ok, [1, 2]}
+  ## Examples
 
-    iex> sequence([{:ok, 1}, {:error, 2}, {:ok, 3}])
-    {:error, 2}
+      iex> sequence([{:ok, 1}, {:ok, 2}])
+      {:ok, [1, 2]}
 
-    iex> sequence([{:error, 1}, {:error, 2}])
-    {:error, 1}
+      iex> sequence([{:ok, 1}, {:error, 2}, {:ok, 3}])
+      {:error, 2}
+
+      iex> sequence([{:error, 1}, {:error, 2}])
+      {:error, 1}
   """
   @spec sequence([either()]) :: {:ok, [any()]} | {:error, any()}
   def sequence(list) do
@@ -174,26 +183,28 @@ defmodule Noether.Either do
   @doc """
   Given an Either and one function, it applies the function to the `{:error, _}` tuple.
 
-  ## EXAMPLES
-    iex> map_error({:ok, 1}, &(&1 + 1))
-    {:ok, 1}
+  ## Examples
 
-    iex> map_error({:error, 1}, &(&1 + 1))
-    {:error, 2}
+      iex> map_error({:ok, 1}, &(&1 + 1))
+      {:ok, 1}
+
+      iex> map_error({:error, 1}, &(&1 + 1))
+      {:error, 2}
   """
   @spec map_error(either(), fun1()) :: either()
   def map_error(k = {:ok, _}, _), do: k
   def map_error({:error, value}, f) when is_function(f, 1), do: {:error, f.(value)}
 
   @doc """
-  Given an Either and two functions, it applies the first or second one on the second value of the tuple, depending if the value is `{:ok, _}` or `{:error, _` respectively.
+  Given an Either and two functions, it applies the first or second one on the second value of the tuple, depending if the value is `{:ok, _}` or `{:error, _}` respectively.
 
-  ## EXAMPLES
-    iex> either({:ok, 1}, &(&1 + 1), &(&1 + 2))
-    {:ok, 2}
+  ## Examples
 
-    iex> either({:error, 1}, &(&1 + 1), &(&1 + 2))
-    {:error, 3}
+      iex> either({:ok, 1}, &(&1 + 1), &(&1 + 2))
+      {:ok, 2}
+
+      iex> either({:error, 1}, &(&1 + 1), &(&1 + 2))
+      {:error, 3}
   """
   @spec either(either(), fun1(), fun1()) :: either()
   def either(k = {:ok, _}, f, _) when is_function(f, 1), do: map(k, f)
@@ -202,12 +213,13 @@ defmodule Noether.Either do
   @doc """
   Given a list of Either, the function is mapped only on the elements of type `{:ok, _}`. Other values will be discarded. A list of the results is returned outside of the tuple.
 
-  ## EXAMPLES
-    iex> cat_either([{:ok, 1}], &(&1 + 1))
-    [2]
+  ## Examples
 
-    iex> cat_either([{:ok, 1}, {:error, 2}, {:ok, 3}], &(&1 + 1))
-    [2, 4]
+      iex> cat_either([{:ok, 1}], &(&1 + 1))
+      [2]
+
+      iex> cat_either([{:ok, 1}, {:error, 2}, {:ok, 3}], &(&1 + 1))
+      [2, 4]
   """
   @spec cat_either([either()], fun1()) :: [any()]
   def cat_either(list, f) when is_function(f, 1) do
@@ -225,15 +237,16 @@ defmodule Noether.Either do
   @doc """
   Given a value and two functions that return an Either, it applies the first one and returns the result if it matches `{:ok, _}`. Otherwise the second function is applied.
 
-  ## EXAMPLES
-    iex> choose(0, fn a -> {:ok, a + 1} end, fn b -> {:ok, b + 2} end)
-    {:ok, 1}
+  ## Examples
 
-    iex> choose(0, fn _ -> {:error, 1} end, fn b -> {:ok, b + 2} end)
-    {:ok, 2}
+      iex> choose(0, fn a -> {:ok, a + 1} end, fn b -> {:ok, b + 2} end)
+      {:ok, 1}
 
-    iex> choose(0, fn _ -> {:error, 1} end, fn _ -> {:error, 2} end)
-    {:error, 2}
+      iex> choose(0, fn _ -> {:error, 1} end, fn b -> {:ok, b + 2} end)
+      {:ok, 2}
+
+      iex> choose(0, fn _ -> {:error, 1} end, fn _ -> {:error, 2} end)
+      {:error, 2}
   """
   @spec choose(either(), fun1(), fun1()) :: either()
   def choose(a, f, g) when is_function(f, 1) and is_function(g, 1) do

--- a/lib/noether/either.ex
+++ b/lib/noether/either.ex
@@ -20,7 +20,7 @@ defmodule Noether.Either do
   """
   @spec map(either(), fun1()) :: either()
   def map({:ok, a}, f) when is_function(f, 1), do: {:ok, f.(a)}
-  def map(any = {:error, _}, _), do: any
+  def map(a = {:error, _}, _), do: a
 
   @doc """
   Given an `{:ok, {:ok, value}}` it flattens the ok unwrapping the `value` and returning `{:ok, value}`.
@@ -43,7 +43,7 @@ defmodule Noether.Either do
   @spec flat_map(either(), fun1()) :: either()
   def flat_map({:ok, {:ok, a}}, f) when is_function(f, 1), do: {:ok, f.(a)}
   def flat_map({:ok, {:error, a}}, _), do: {:error, a}
-  def flat_map(any = {:error, _}, _), do: any
+  def flat_map(a = {:error, _}, _), do: a
 
   @doc """
   Given an `{:ok, {:ok, value}}` it flattens the ok unwrapping the `value` and returning `{:ok, value}`.
@@ -63,7 +63,7 @@ defmodule Noether.Either do
   @spec join(either()) :: either()
   def join({:ok, {:ok, a}}), do: {:ok, a}
   def join({:ok, {:error, a}}), do: {:error, a}
-  def join(any = {:error, _}), do: any
+  def join(a = {:error, _}), do: a
 
   @doc """
   Given an `{:ok, value}` and a function that returns an Either value, it applies the function on the `value`. It effectively "squashes" an `{:ok, {:ok, v}}` or `{:ok, {:error, _}}` to its most appropriate representation.
@@ -82,7 +82,7 @@ defmodule Noether.Either do
   """
   @spec bind(either(), fun1()) :: either()
   def bind({:ok, a}, f) when is_function(f, 1), do: f.(a)
-  def bind(any = {:error, _}, _), do: any
+  def bind(a = {:error, _}, _), do: a
 
   @doc """
   Given any value, it makes sure the result is an Either type.
@@ -99,9 +99,9 @@ defmodule Noether.Either do
       {:ok, 3}
   """
   @spec wrap(any()) :: either()
-  def wrap(k = {:ok, _}), do: k
-  def wrap(e = {:error, _}), do: e
-  def wrap(any), do: {:ok, any}
+  def wrap(a = {:ok, _}), do: a
+  def wrap(a = {:error, _}), do: a
+  def wrap(a), do: {:ok, a}
 
   @doc """
   It returns the value of an `{:ok, value}` only if such a tuple is given. If not, `nil` is returned.
@@ -115,7 +115,7 @@ defmodule Noether.Either do
       nil
   """
   @spec unwrap({:ok, any()}) :: any()
-  def unwrap({:ok, v}), do: v
+  def unwrap({:ok, a}), do: a
   def unwrap(_), do: nil
 
   @doc """
@@ -133,7 +133,7 @@ defmodule Noether.Either do
       false
   """
   @spec ok?(any()) :: boolean()
-  def ok?(any), do: match?({:ok, _}, any)
+  def ok?(a), do: match?({:ok, _}, a)
 
   @doc """
   It returns `true` only if the value given matches a `{:error, value}` type.
@@ -150,7 +150,7 @@ defmodule Noether.Either do
       false
   """
   @spec error?(any()) :: boolean()
-  def error?(any), do: match?({:error, _}, any)
+  def error?(a), do: match?({:error, _}, a)
 
   @doc """
   Given a list of Either, it returns `{:ok, list}` if every element of the list is of type `{:ok, _}`. Otherwise the first `{:error, _}` is returned.
@@ -167,14 +167,14 @@ defmodule Noether.Either do
       {:error, 1}
   """
   @spec sequence([either()]) :: {:ok, [any()]} | {:error, any()}
-  def sequence(list) do
-    list
+  def sequence(a) do
+    a
     |> Enum.reduce(
       {:ok, []},
       fn
-        _, e = {:error, _} -> e
-        e = {:error, _}, _ -> e
-        {:ok, value}, {:ok, acc} -> {:ok, [value | acc]}
+        _, error = {:error, _} -> error
+        error = {:error, _}, _ -> error
+        {:ok, b}, {:ok, acc} -> {:ok, [b | acc]}
       end
     )
     |> map(&Enum.reverse/1)
@@ -192,8 +192,8 @@ defmodule Noether.Either do
       {:error, 2}
   """
   @spec map_error(either(), fun1()) :: either()
-  def map_error(k = {:ok, _}, _), do: k
-  def map_error({:error, value}, f) when is_function(f, 1), do: {:error, f.(value)}
+  def map_error(a = {:ok, _}, _), do: a
+  def map_error({:error, a}, f) when is_function(f, 1), do: {:error, f.(a)}
 
   @doc """
   Given an Either and two functions, it applies the first or second one on the second value of the tuple, depending if the value is `{:ok, _}` or `{:error, _}` respectively.
@@ -207,8 +207,8 @@ defmodule Noether.Either do
       {:error, 3}
   """
   @spec either(either(), fun1(), fun1()) :: either()
-  def either(k = {:ok, _}, f, _) when is_function(f, 1), do: map(k, f)
-  def either({:error, value}, _, g) when is_function(g, 1), do: {:error, g.(value)}
+  def either(a = {:ok, _}, f, _) when is_function(f, 1), do: map(a, f)
+  def either({:error, a}, _, g) when is_function(g, 1), do: {:error, g.(a)}
 
   @doc """
   Given a list of Either, the function is mapped only on the elements of type `{:ok, _}`. Other values will be discarded. A list of the results is returned outside of the tuple.
@@ -222,13 +222,13 @@ defmodule Noether.Either do
       [2, 4]
   """
   @spec cat_either([either()], fun1()) :: [any()]
-  def cat_either(list, f) when is_function(f, 1) do
-    list
+  def cat_either(a, f) when is_function(f, 1) do
+    a
     |> Enum.reduce(
       [],
       fn
         {:error, _}, acc -> acc
-        {:ok, value}, acc -> [f.(value) | acc]
+        {:ok, b}, acc -> [f.(b) | acc]
       end
     )
     |> Enum.reverse()

--- a/lib/noether/list.ex
+++ b/lib/noether/list.ex
@@ -6,9 +6,10 @@ defmodule Noether.List do
   @doc """
   Given two lists and a function of arity 2, the lists are first zipped and then each tuple is applied (curried) to the function.
 
-  ## EXAMPLES
-    iex> zip_with([1, 2, 3], [4, 5, 6], &Kernel.+/2)
-    [5, 7, 9]
+  ## Examples
+
+      iex> zip_with([1, 2, 3], [4, 5, 6], &Kernel.+/2)
+      [5, 7, 9]
   """
   @spec zip_with([any()], [any()], fun()) :: [any()]
   def zip_with(a, b, f) do
@@ -20,9 +21,10 @@ defmodule Noether.List do
   @doc """
   Given a predicate, a function of arity 1, and a value, the function is applied repeatedly until the predicate applied to the value returns either `nil`, `false`, or `{:error, _}`. The list of results is returned.
 
-  ## EXAMPLES
-    iex> until(fn a -> a < 10 end, &(&1 + 1), 0)
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  ## Examples
+
+      iex> until(fn a -> a < 10 end, &(&1 + 1), 0)
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   """
   @spec until(fun(), fun(), any()) :: [any()]
   def until(p, f, a) do

--- a/lib/noether/list.ex
+++ b/lib/noether/list.ex
@@ -3,6 +3,9 @@ defmodule Noether.List do
 
   import Noether
 
+  @type fun1 :: (any() -> any())
+  @type fun2 :: (any(), any() -> any())
+
   @doc """
   Given two lists and a function of arity 2, the lists are first zipped and then each tuple is applied (curried) to the function.
 
@@ -11,8 +14,8 @@ defmodule Noether.List do
       iex> zip_with([1, 2, 3], [4, 5, 6], &Kernel.+/2)
       [5, 7, 9]
   """
-  @spec zip_with([any()], [any()], fun()) :: [any()]
-  def zip_with(a, b, f) do
+  @spec zip_with([any()], [any()], fun2()) :: [any()]
+  def zip_with(a, b, f) when is_function(f, 2) do
     a
     |> Enum.zip(b)
     |> Enum.map(&curry(&1, f))
@@ -26,8 +29,8 @@ defmodule Noether.List do
       iex> until(fn a -> a < 10 end, &(&1 + 1), 0)
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   """
-  @spec until(fun(), fun(), any()) :: [any()]
-  def until(p, f, a) do
+  @spec until(fun1(), fun1(), any()) :: [any()]
+  def until(p, f, a) when is_function(p, 1) and is_function(f, 1) do
     case p.(a) do
       nil ->
         []

--- a/lib/noether/maybe.ex
+++ b/lib/noether/maybe.ex
@@ -6,12 +6,13 @@ defmodule Noether.Maybe do
   @doc """
   Given a value and a function, the function is applied only if the value is different from `nil`. `nil` is returned otherwise.
 
-  ## EXAMPLES
-    iex> map(nil, &Kernel.abs/1)
-    nil
+  ## Examples
 
-    iex> map(-1, &Kernel.abs/1)
-    1
+      iex> map(nil, &Kernel.abs/1)
+      nil
+
+      iex> map(-1, &Kernel.abs/1)
+      1
   """
   @spec map(any(), fun()) :: any()
   def map(nil, _), do: nil
@@ -20,12 +21,13 @@ defmodule Noether.Maybe do
   @doc """
   Given a value and a default, `{:ok, value}` is returned only if the value is different from `nil`. `{:error, default}` is returned otherwise.
 
-  ## EXAMPLES
-    iex> required(nil, :hello)
-    {:error, :hello}
+  ## Examples
 
-    iex> required(1, :hello)
-    {:ok, 1}
+      iex> required(nil, :hello)
+      {:error, :hello}
+
+      iex> required(1, :hello)
+      {:ok, 1}
   """
   @spec required(any(), any()) :: Either.either()
   def required(nil, default), do: {:error, default}
@@ -34,12 +36,13 @@ defmodule Noether.Maybe do
   @doc """
   Given a list, it returns `{:ok, list}` if every element of the list is different from nil. Otherwise `{:error, :nil_found}` is returned.
 
-  ## EXAMPLES
-    iex> sequence([1, 2])
-    {:ok, [1, 2]}
+  ## Examples
 
-    iex> sequence([1, nil, 3])
-    {:error, :nil_found}
+      iex> sequence([1, 2])
+      {:ok, [1, 2]}
+
+      iex> sequence([1, nil, 3])
+      {:error, :nil_found}
   """
   @spec sequence([any()]) :: Either.either()
   def sequence(list) do
@@ -58,12 +61,13 @@ defmodule Noether.Maybe do
   @doc """
   Given a value, a function, and a default, it applies the function on the value if the latter is different from `nil`. It returns the default otherwise.
 
-  ## EXAMPLES
-    iex> maybe(-1, &Kernel.abs/1, :hello)
-    1
+  ## Examples
 
-    iex> maybe(nil, &Kernel.abs/1, :hello)
-    :hello
+      iex> maybe(-1, &Kernel.abs/1, :hello)
+      1
+
+      iex> maybe(nil, &Kernel.abs/1, :hello)
+      :hello
   """
   @spec maybe(any(), fun(), any()) :: any()
   def maybe(nil, _, default), do: default
@@ -72,12 +76,12 @@ defmodule Noether.Maybe do
   @doc """
   Given a list of values, the function is mapped only on the elements different from `nil`. `nil` values will be discarded. A list of the results is returned.
 
-  ## EXAMPLES
-    iex> cat_maybe([1], &(&1 + 1))
-    [2]
+  ## Examples
+      iex> cat_maybe([1], &(&1 + 1))
+      [2]
 
-    iex> cat_maybe([1, nil, 3], &(&1 + 1))
-    [2, 4]
+      iex> cat_maybe([1, nil, 3], &(&1 + 1))
+      [2, 4]
   """
   @spec cat_maybe([any()], fun()) :: [any()]
   def cat_maybe(list, f) do
@@ -92,15 +96,16 @@ defmodule Noether.Maybe do
   @doc """
   Given a value and two functions, it applies the first one and returns the result if it's different from nil. Otherwise the second function is applied.
 
-  ## EXAMPLES
-    iex> choose(0, fn a -> a + 1 end, fn b -> b + 2 end)
-    1
+  ## Examples
 
-    iex> choose(0, fn _ -> nil end, fn b -> b + 2 end)
-    2
+      iex> choose(0, fn a -> a + 1 end, fn b -> b + 2 end)
+      1
 
-    iex> choose(0, fn _ -> nil end, fn _ -> nil end)
-    nil
+      iex> choose(0, fn _ -> nil end, fn b -> b + 2 end)
+      2
+
+      iex> choose(0, fn _ -> nil end, fn _ -> nil end)
+      nil
   """
   @spec choose(any(), fun(), fun()) :: any()
   def choose(a, f, g) do

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Noether.MixProject do
 
   defp package do
     [
-      maintainers: ["Tommaso Pifferi", "Giovanni Ornaghi"],
+      maintainers: ["Tommaso Pifferi", "Simone Cottini", "Giovanni Ornaghi"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/sphaso/noether"}
     ]


### PR DESCRIPTION
Not to merge before #10.

@neslinesli93 @cottinisimone 
we might want to have a naming convention for function parameters. Looking at the docs it looks a bit like word salad. We have `cat_maybe(list, f)` along with `choose(a, f, g) ` or `map(v, f) `.

I like to use `f` and `g` for functions as in standard maths notation, not so sure about value arguments. Do you guys have any idea?