### PR TITLE
fix spec of Either.choose

### DIFF
--- a/lib/noether/either.ex
+++ b/lib/noether/either.ex
@@ -306,7 +306,7 @@ defmodule Noether.Either do
       iex> choose(0, fn _ -> {:error, 1} end, fn _ -> {:error, 2} end)
       {:error, 2}
   """
-  @spec choose(either(), fun1(), fun1()) :: either()
+  @spec choose(any(), fun1(), fun1()) :: either()
   def choose(a, f, g) when is_function(f, 1) and is_function(g, 1) do
     b = f.(a)
 


### PR DESCRIPTION
Input of `Noether.Either.choose` is not an `either()` but `any()`, as shown in the example