### PR TITLE
Add Either.or_else function

### DIFF
--- a/lib/noether/either.ex
+++ b/lib/noether/either.ex
@@ -4,6 +4,7 @@ defmodule Noether.Either do
   These type of values will be then called `Either`.
   """
   @type either :: {:ok, any()} | {:error, any()}
+  @type fun0 :: (() -> any())
   @type fun1 :: (any() -> any())
 
   @doc """
@@ -267,6 +268,25 @@ defmodule Noether.Either do
   @spec either(either(), fun1(), fun1()) :: either()
   def either(a = {:ok, _}, f, _) when is_function(f, 1), do: map(a, f)
   def either({:error, a}, _, g) when is_function(g, 1), do: {:error, g.(a)}
+
+  @doc """
+  Given an Either and a function, it returns the value as-is when it's ok, or executes the function and returns its result.
+
+  ## Examples
+
+      iex> or_else({:ok, 1}, fn -> {:ok, 2} end)
+      {:ok, 1}
+
+      iex> or_else({:error, 1}, fn -> {:ok, 2} end)
+      {:ok, 2}
+
+      iex> or_else({:error, 1}, fn x -> {:ok, x + 2} end)
+      {:ok, 3}
+  """
+  @spec or_else(either(), fun0() | fun1()) :: either()
+  def or_else(a = {:ok, _}, _), do: a
+  def or_else({:error, _error}, f) when is_function(f, 0), do: f.()
+  def or_else({:error, error}, f) when is_function(f, 1), do: f.(error)
 
   @doc """
   Given a list of Either, the function is mapped only on the elements of type `{:ok, _}`. Other values will be discarded. A list of the results is returned outside of the tuple.

--- a/lib/noether/either.ex
+++ b/lib/noether/either.ex
@@ -274,19 +274,17 @@ defmodule Noether.Either do
 
   ## Examples
 
-      iex> or_else({:ok, 1}, fn -> {:ok, 2} end)
+      iex> or_else({:ok, 1}, fn _ -> {:ok, 2} end)
       {:ok, 1}
 
-      iex> or_else({:error, 1}, fn -> {:ok, 2} end)
+      iex> or_else({:error, 1}, fn _ -> {:ok, 2} end)
       {:ok, 2}
 
       iex> or_else({:error, 1}, fn x -> {:ok, x + 2} end)
       {:ok, 3}
   """
-  @spec or_else(either(), fun0() | fun1()) :: either()
-  def or_else(a = {:ok, _}, _), do: a
-  def or_else({:error, _error}, f) when is_function(f, 0), do: f.()
-  def or_else({:error, error}, f) when is_function(f, 1), do: f.(error)
+  @spec or_else(either(), fun1()) :: either()
+  def or_else(a, f), do: choose(a, & &1, fn {_, e} -> f.(e) end)
 
   @doc """
   Given a list of Either, the function is mapped only on the elements of type `{:ok, _}`. Other values will be discarded. A list of the results is returned outside of the tuple.


### PR DESCRIPTION
Adds an `or_else` function on Either.

When the either value is an `{:ok, value}` it is returned as-is. 

On error, it executes the function and returns the value, which allows to return an `{:ok, value}` even though the incoming value is an error. 

If I understand correctly, using Either.either for this situation (based on issue #34) would return an `{:error, {:ok, value}}` which can be a bit complex to manage.

Hope it helps :smile: 