### PR TITLE
Deprecate zip_with in favor of Enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The root module has a few simple functions one might find of use.
 ```elixir
 def deps do
   [
-    {:noether, "~> 0.2.5"}
+    {:noether, "~> 0.3.0"}
   ]
 end
 ```

--- a/lib/noether/list.ex
+++ b/lib/noether/list.ex
@@ -15,6 +15,7 @@ defmodule Noether.List do
       iex> zip_with([1, 2, 3], [4, 5, 6], &Kernel.+/2)
       [5, 7, 9]
   """
+  @deprecated "use Enum.zip_with/3 instead"
   @spec zip_with([any()], [any()], fun2()) :: [any()]
   def zip_with(a, b, f) when is_function(f, 2) do
     a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Noether.MixProject do
   def project do
     [
       app: :noether,
-      version: "0.2.5",
+      version: "0.3.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Enum.zip_with exists since v.1.13.4 so there is no reason to have our own version.